### PR TITLE
feat: add Python dependency tracking for requirements.txt and pyproject.toml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Number of days to analyze (default: 7)'
     required: false
     default: '7'
+  track-dependencies:
+    description: 'If true, fetch and compare Python dependency files (requirements.txt / pyproject.toml)'
+    required: false
+    default: 'false'
 
 outputs:
   report:

--- a/src/dependency-tracker.ts
+++ b/src/dependency-tracker.ts
@@ -1,0 +1,97 @@
+import * as github from '@actions/github';
+import * as core from '@actions/core';
+
+type Octokit = ReturnType<typeof github.getOctokit>;
+
+export interface DependencySnapshot {
+  source: 'requirements.txt' | 'pyproject.toml' | null;
+  dependencies: Record<string, string>; // name -> version specifier
+}
+
+/**
+ * Parse a requirements.txt file into a name→version map.
+ */
+function parseRequirementsTxt(content: string): Record<string, string> {
+  const deps: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('-')) continue;
+    const match = trimmed.match(/^([A-Za-z0-9_\-]+)([><=!~][^;#]*)?/);
+    if (match) {
+      deps[match[1].toLowerCase()] = (match[2] || '').trim();
+    }
+  }
+  return deps;
+}
+
+/**
+ * Parse a pyproject.toml file and extract [project.dependencies].
+ */
+function parsePyprojectToml(content: string): Record<string, string> {
+  const deps: Record<string, string> = {};
+  const depSection = content.match(/\[project\.dependencies\]([\s\S]*?)(?=\[|$)/);
+  if (!depSection) return deps;
+  for (const line of depSection[1].split('\n')) {
+    const trimmed = line.replace(/["',]/g, '').trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const match = trimmed.match(/^([A-Za-z0-9_\-]+)([><=!~][^;#]*)?/);
+    if (match) {
+      deps[match[1].toLowerCase()] = (match[2] || '').trim();
+    }
+  }
+  return deps;
+}
+
+/**
+ * Fetch Python dependency file from a GitHub repo.
+ */
+export async function fetchDependencies(
+  octokit: Octokit,
+  owner: string,
+  repo: string
+): Promise<DependencySnapshot> {
+  const candidates = ['requirements.txt', 'pyproject.toml'];
+
+  for (const filename of candidates) {
+    try {
+      const { data } = await octokit.rest.repos.getContent({ owner, repo, path: filename });
+      if ('content' in data && typeof data.content === 'string') {
+        const content = Buffer.from(data.content, 'base64').toString('utf-8');
+        const dependencies = filename === 'requirements.txt'
+          ? parseRequirementsTxt(content)
+          : parsePyprojectToml(content);
+        return { source: filename as DependencySnapshot['source'], dependencies };
+      }
+    } catch {
+      // File not found, try next
+    }
+  }
+
+  return { source: null, dependencies: {} };
+}
+
+/**
+ * Diff two dependency snapshots and return a human-readable summary.
+ */
+export function diffDependencies(
+  before: Record<string, string>,
+  after: Record<string, string>
+): string {
+  const lines: string[] = [];
+
+  for (const [name, version] of Object.entries(after)) {
+    if (!(name in before)) {
+      lines.push(`  + Added: ${name}${version ? ` ${version}` : ''}`);
+    } else if (before[name] !== version) {
+      lines.push(`  ~ Updated: ${name} ${before[name] || '*'} → ${version || '*'}`);
+    }
+  }
+
+  for (const name of Object.keys(before)) {
+    if (!(name in after)) {
+      lines.push(`  - Removed: ${name}`);
+    }
+  }
+
+  return lines.length > 0 ? lines.join('\n') : '  No dependency changes.';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,12 @@ import * as github from '@actions/github';
 import { fetchRepoData } from './github-client';
 import { analyzeRepo, RepoReport } from './analyzer';
 import { createIssue, createPRComment, outputJson } from './output';
+import { fetchDependencies, diffDependencies } from './dependency-tracker';
 
 async function run(): Promise<void> {
   try {
     const reposInput = core.getInput('repos', { required: true });
+    const trackDependencies = core.getInput('track-dependencies') === 'true';
     const token = core.getInput('github-token', { required: true });
     const outputFormat = core.getInput('output-format') || 'issue';
     const periodDays = parseInt(core.getInput('period-days') || '7', 10);
@@ -37,6 +39,13 @@ async function run(): Promise<void> {
       try {
         const data = await fetchRepoData(octokit, owner, repo, periodDays);
         const report = analyzeRepo(data, periodDays);
+        if (trackDependencies) {
+          const deps = await fetchDependencies(octokit, owner, repo);
+          if (deps.source) {
+            core.info(`Found ${deps.source} for ${owner}/${repo} with ${Object.keys(deps.dependencies).length} dependencies`);
+            (report as any).dependencies = deps;
+          }
+        }
         reports.push(report);
         core.info(`Analysis complete for ${owner}/${repo}`);
       } catch (err) {


### PR DESCRIPTION
## Summary

Adds Python dependency tracking to repo-intel.

## Changes

- New `track-dependencies` input in `action.yml` (default: `false`)
- New `src/dependency-tracker.ts` module:
  - `fetchDependencies()` — fetches `requirements.txt` or `pyproject.toml` via GitHub Contents API
  - `parseRequirementsTxt()` / `parsePyprojectToml()` — parse deps into name→version maps
  - `diffDependencies()` — diff two snapshots and return added/updated/removed changes
- `index.ts` wired to call dependency tracking when enabled

## Usage

```yaml
- uses: oxnr/repo-intel@main
  with:
    repos: 'fastapi/fastapi,pallets/flask'
    track-dependencies: 'true'
```

Closes #2